### PR TITLE
Resolve Issue #4 - Fix image paths via transforms

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -30,11 +30,31 @@ module.exports = function(eleventyConfig) {
         return item;
       });
   });
-  // Get static assets like images
-  eleventyConfig.addPassthroughCopy('site/notes/*.jpg', './');
-  eleventyConfig.addPassthroughCopy('site/notes/*.jpeg', './');
-  eleventyConfig.addPassthroughCopy('site/notes/*.png', './');
-  eleventyConfig.addPassthroughCopy('site/notes/*.svg', './');
+
+  // Ignore all files except markdown in the notes folder
+  eleventyConfig.setTemplateFormats(['liquid', 'md', 'njk', 'html', 'css', 'png', 'jpg', 'jpeg']);
+
+  //Modify any image paths to be relative to the root
+  eleventyConfig.addTransform('imgPath', function(content, outputPath) {
+    if (outputPath && outputPath.endsWith('.html')) {
+      const imgPathRegex = /(<img.*?src=")(.*?)"/g;
+      content = content.replace(imgPathRegex, function(_, p1, p2) {
+        // If the path has a current relative directory mark,
+        // replace it with a parent dir mark
+        let newTag = '';
+        if (p2.startsWith('./')) {
+          newTag = `${p1}${p2.replace('./', '../')}"`;
+        } // If the path has no relative directory mark, add a parent dir mark
+        else if (!p2.startsWith('../')) {
+          newTag = `${p1}../${p2}"`;
+        } else { // Otherwise just return the original tag
+          newTag = `${p1}${p2}"`;
+        } return newTag;
+      });
+    }
+
+    return content;
+  });
 
   // Add debugger filter to debug data passed to templates
    eleventyConfig.addFilter('debugger', function(item) {
@@ -47,6 +67,6 @@ module.exports = function(eleventyConfig) {
     dir: {
       input: 'site',
       output: '_site',
-    },
+    }
   };
 };

--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ your new changes automatically.
 Congratulations—you made something with Eleventy!
 Now put it to work with templating syntax, front matter, and data files.
 
-
 ## Eleventy Configuration
 
 This is where all the logic happens, **FILL IN DOCUMENTATION**.
@@ -392,6 +391,8 @@ module.exports = function(eleventyConfig) {
 
 ## References
 
+### Web Links
+
 * [Eleventy (11ty) Homepage][11ty]
 * [mdman: Markdown Frontmatter file utilities (from Github)][mg-mdman-gh]
 * [Getting Started (from 11ty.dev/docs)][11ty-get-start]
@@ -400,8 +401,10 @@ module.exports = function(eleventyConfig) {
 * [Layouts (from 11ty.dev/docs)][11ty-layouts]
 * [Collections: Custom Filtering & Sorting (from 11ty.dev/docs)][11ty-collections-custom-filt-sort]
 * [Tips for Debugging 11ty (from griffa.dev)][griffa-tips-debug-11ty]
+* [Transform (from 11ty.dev/docs)][11ty-docs-config-transform]
 * [gray-matter: Frontmatter YAML parser (from Github by jonschlinkert)][gh-gray-matter]
 * [Global Data (from 11ty.dev/docs)][11ty-data-global]
+* [Why I Migrated from Gatsby to Eleventy (from marcradziwill by Marc Radziwill)][why-gatsby-to-11ty-radziwill]
 
 <!-- Hidden Reference Links Below Here -->
 [11ty]: 11ty.dev "Eleventy (11ty) Homepage"
@@ -412,8 +415,10 @@ module.exports = function(eleventyConfig) {
 [11ty-layouts]: https://www.11ty.dev/docs/layouts/ "Layouts (from 11ty.dev/docs)"
 [11ty-collections-custom-filt-sort]: https://www.11ty.dev/docs/collections/#advanced-custom-filtering-and-sorting "Collections: Custom Filtering & Sorting (from 11ty.dev/docs)"
 [griffa-tips-debug-11ty]: https://griffa.dev/posts/tips-for-debugging-in-11ty/ "Tips for Debugging 11ty (from griffa.dev)"
+[11ty-docs-config-transform]: https://www.11ty.dev/docs/config/#transforms "Transform (from 11ty.dev/docs)"
 [gh-gray-matter]: https://github.com/jonschlinkert/gray-matter "gray-matter: Frontmatter YAML parser (from Github by jonschlinkert)"
 [11ty-data-global]: https://www.11ty.dev/docs/data-global/ "Global Data (from 11ty.dev/docs)"
+[why-gatsby-to-11ty-radziwill]: ./https://marcradziwill.com/blog/why-i-migrated-my-website-from-gatsbyjs-to-eleventy/ "Why I Migrated from Gatsby to Eleventy (from marcradziwill by Marc Radziwill)"
 
 ### Note Links
 


### PR DESCRIPTION
* By using eleventyConfig.addTransform()...
  * It's possible to modify the path of the image after the HTML is rendered
  * This was done by checking for flat filenames or `./` relative paths
  * Replacing them with `../` you get the actual path of the images