### PR TITLE
Add markdown-it-replace-link for correct md links

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,3 +1,37 @@
+const transformMarkdownLink = function(link, url) {
+  // // Remove the .md extension
+  // const newLink = link.replace(/\.md$/, '');
+  // // Remove the ./ prefix if it exists
+  // if (newLink.startsWith('./')) {
+  //   newLink = newLink.replace('./', '');
+  // }
+  // // Now with no relative path prefix, add a parent directory prefix
+  // newLink = `../${newLink}`;
+  // return newLink;
+  const noteUrl = `${url}/notes/`;
+  return noteUrl + link.replace(/\.md$/, '') // Remove the .md extension
+                      .replace(/^\.\//, '') // Remove ./ prefix if it exists
+                      .replace(/\.\.\//g, ''); // Remove parent prefix (../)
+};
+
+const replaceLink = function(link, env, token, htmlToken) {
+  if (link.endsWith('.md')) return transformMarkdownLink(link, env.meta.url);
+  // TODO: Use this method to change location of image link types
+};
+
+const mdOptions = {
+  html: true,
+  linkify: true,
+  replaceLink: replaceLink,
+};
+
+const mdIt = require('markdown-it')({
+  html: true,
+  linkify: true,
+  replaceLink,
+}).use(require('markdown-it-replace-link'));
+
+// Root eleventy config export
 module.exports = function(eleventyConfig) {
   // Add global data
   eleventyConfig.addGlobalData('meta', {
@@ -7,6 +41,9 @@ module.exports = function(eleventyConfig) {
       + 'built with Eleventy & the Zettelkasten method.'),
     authorName: 'Marcus Grant',
   });
+
+  // Markdown-it customizations
+  eleventyConfig.setLibrary('md', mdIt);
 
   // Add notes to collection
   eleventyConfig.addCollection('notes', function(collection) {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,4 +7,5 @@
         "./site/notes",
     ],
     "liquid.format.enable": true,
+    "editor.rulers": [80, 100, 120],
 }

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ module.exports = {
 };
 ```
 
-#### Further Reading
+#### Eleventy Debugging: Further Reading
 
 A lot of this section's tips came from these
 [tips for debugging 11ty (from griffa.dev)][griffa-tips-debug-11ty].
@@ -370,7 +370,7 @@ we simply do something like this to render the title into HTML.
 {%- endfor -%}
 ```
 
-### Further Reading
+### Eleventy Collections: Further Reading
 
 A lot of this information came from this
 [part of 11ty's docs on custom filtering & sorting][11ty-collections-custom-filt-sort]
@@ -391,6 +391,84 @@ module.exports = function(eleventyConfig) {
   });
 ```
 
+## Markdown-It
+
+### Install Markdown-It
+
+Markdown-It is the default markdown parser for 11ty.
+To install it:
+
+```sh
+npm install markdown-it
+```
+
+### Configure Markdown-It
+
+Here is some example configuration for markdown-it.
+
+```js
+// ./.eleventy.js
+const md = require('markdown-it')({
+  html: true,
+  linkify: true,
+  // ... other options ...
+});
+```
+
+### Markdown-It Plugins
+
+To install a plugin for markdown-it,
+you can use the `use` method on the markdown-it instance.
+
+```js
+// ./.eleventy.js
+const md = require('markdown-it')({
+  html: true,
+  linkify: true,
+  // ... other options ...
+}).use(require('markdown-it-replace-link'));
+```
+
+In the next section is information on some of the specific plugin usages of
+some of the more common ones I use.
+Starting with the [markdown-it-replace-link][md-it-plug-replace-link] plugin.
+
+### Markdown-It Replace Link
+
+The plugin [markdown-it-replace-link][md-it-plug-replace-link] allows you to
+insert special replacement functions for the incoming text of a link.
+This happens when markdown-it is parsing the text of a link,
+and it's about to create a link element.
+To install it:
+
+```sh
+npm install markdown-it-replace-link
+```
+
+Then in your 11ty configuration,
+Assuming the markdown link syntax below,
+of text `Hello` & link URL `test`,
+and the following eleventy configuration using this plugin.
+
+```markdown
+[Hello](test)
+```
+
+```js
+// ./.eleventy.js
+const md = require('markdown-it')({
+  html: true,
+  linkify: true,
+  replaceLink: function(link, env, token, htmlToken){
+    return 'https://example.com/' + link;
+  }
+  // ... other options ...
+}).use(require('markdown-it-replace-link'));
+```
+
+Now every link in the markdown files will be prefixed with `https://example.com/`.
+So the example markdown link above would become: `https://example.com/test`.
+
 ## References
 
 ### Web Links
@@ -407,6 +485,7 @@ module.exports = function(eleventyConfig) {
 * [gray-matter: Frontmatter YAML parser (from Github by jonschlinkert)][gh-gray-matter]
 * [Global Data (from 11ty.dev/docs)][11ty-data-global]
 * [Why I Migrated from Gatsby to Eleventy (from marcradziwill by Marc Radziwill)][why-gatsby-to-11ty-radziwill]
+* [markdown-it-replace-link: Markdown-It plugin for replacing links (from GitHub by Martin Heidegger)][md-it-plug-replace-link]
 
 <!-- Hidden Reference Links Below Here -->
 [11ty]: 11ty.dev "Eleventy (11ty) Homepage"
@@ -421,6 +500,7 @@ module.exports = function(eleventyConfig) {
 [gh-gray-matter]: https://github.com/jonschlinkert/gray-matter "gray-matter: Frontmatter YAML parser (from Github by jonschlinkert)"
 [11ty-data-global]: https://www.11ty.dev/docs/data-global/ "Global Data (from 11ty.dev/docs)"
 [why-gatsby-to-11ty-radziwill]: ./https://marcradziwill.com/blog/why-i-migrated-my-website-from-gatsbyjs-to-eleventy/ "Why I Migrated from Gatsby to Eleventy (from marcradziwill by Marc Radziwill)"
+[md-it-plug-replace-link]: https://github.com/martinheidegger/markdown-it-replace-link "markdown-it-replace-link: Markdown-It plugin for replacing links (from GitHub by Martin Heidegger)"
 
 ### Note Links
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "hasInstallScript": true,
       "license": "AGPLv3",
       "dependencies": {
+        "markdown-it": "^13.0.1",
+        "markdown-it-replace-link": "^1.2.0",
         "notes": "github:marcus-grant/notes#main"
       },
       "devDependencies": {
@@ -88,6 +90,46 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/11ty"
+      }
+    },
+    "node_modules/@11ty/eleventy/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/@11ty/eleventy/node_modules/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@11ty/eleventy/node_modules/linkify-it": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "dev": true,
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
+    "node_modules/@11ty/eleventy/node_modules/markdown-it": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -865,6 +907,73 @@
       "integrity": "sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ==",
       "dev": true
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "optional": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "optional": true
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "optional": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+      "optional": true,
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/easy-extender": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.4.tgz",
@@ -999,10 +1108,12 @@
       }
     },
     "node_modules/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
-      "dev": true,
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "engines": {
+        "node": ">=0.12"
+      },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
@@ -1441,6 +1552,37 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
+      "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "optional": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "entities": "^4.3.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -1773,10 +1915,9 @@
       "dev": true
     },
     "node_modules/linkify-it": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
-      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
-      "dev": true,
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
       "dependencies": {
         "uc.micro": "^1.0.1"
       }
@@ -1909,14 +2050,13 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "12.3.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
-      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
-      "dev": true,
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.1.tgz",
+      "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "~2.1.0",
-        "linkify-it": "^3.0.1",
+        "entities": "~3.0.1",
+        "linkify-it": "^4.0.1",
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
       },
@@ -1924,11 +2064,19 @@
         "markdown-it": "bin/markdown-it.js"
       }
     },
+    "node_modules/markdown-it-replace-link": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-replace-link/-/markdown-it-replace-link-1.2.0.tgz",
+      "integrity": "sha512-tIsShJvQOYwTHjIPhE1SWo12HjOtpEqSQfVoApm3fuIkVcZrSE7zK3iW8kXcaJYasf8Ddf+VbH5fNXCzfejOrQ==",
+      "optionalDependencies": {
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^8.0.1"
+      }
+    },
     "node_modules/markdown-it/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/maximatch": {
       "version": "0.1.0",
@@ -2007,8 +2155,7 @@
     "node_modules/mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
-      "dev": true
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -3374,8 +3521,7 @@
     "node_modules/uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
-      "dev": true
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "node_modules/uglify-js": {
       "version": "3.17.4",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   "author": "",
   "license": "AGPLv3",
   "dependencies": {
+    "markdown-it": "^13.0.1",
+    "markdown-it-replace-link": "^1.2.0",
     "notes": "github:marcus-grant/notes#main"
   },
   "devDependencies": {


### PR DESCRIPTION
* Resolves #9
* Add markdown-it to render markdown
* Add markdown-it-replace-link to replace links with correct url
  * transformMarkdownLink gets called for each link in the markdown
  * It gets called by replaceLink
    * this function handles different kinds of links
    * For now it only checks for links ending with .md