### PR TITLE
Fix #14: Un-require removed mathjax packages

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -38,7 +38,6 @@ const mdIt = require('markdown-it')({
   replaceLink,
 }).use(
   require('markdown-it-replace-link'),
-  require('markdown-it-mathjax3'),
 );
 
 // Root eleventy config export


### PR DESCRIPTION
* markdown-it plugin mathjax3 was being required after uninstalling
* causing build errors
* removed the require statements and all references to it
* builds now