### PR TITLE
Add eleventy-plugin-syntaxhighlight partial #15

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -53,9 +53,11 @@ module.exports = function(eleventyConfig) {
 
   eleventyConfig.addPlugin(require("eleventy-plugin-mathjax"));
   
-
   // Markdown-it customizations
   eleventyConfig.setLibrary('md', mdIt);
+
+  // Add syntax highlighting plugin
+  eleventyConfig.addPlugin(require("@11ty/eleventy-plugin-syntaxhighlight"));
 
   // Add notes to collection
   eleventyConfig.addCollection('notes', function(collection) {

--- a/README.md
+++ b/README.md
@@ -550,6 +550,29 @@ md.use(mathjax3);
 var result = md.render('# Math Rulez! \n  $\\sqrt{3x-1}+(1+x)^2$');
 ```
 
+## Eleventy Plugins
+
+### Eleventy-Plugin-SyntaxHighlight
+
+#### Syntax Highlighting Plugin
+
+A pack of 11ty plugins for PrismJS
+
+#### Install Highlight Plugin
+
+```sh
+npm install @11ty/eleventy-plugin-syntaxhighlight --save-dev
+```
+
+```js
+// ./.eleventy.js
+const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
+
+module.exports = function(eleventyConfig) {
+  eleventyConfig.addPlugin(syntaxHighlight);
+};
+```
+
 ### Eleventy-Plugin-MathJax
 
 In the end I found this plugin the easiest to use.
@@ -557,13 +580,13 @@ Though I would have preferred to use a markdown-it plugin,
 but being based on eleventy it's reasonable to expect more simplicity and
 tighter coupling to the workflow of the project.
 
-#### Install
+#### Install Eleventy-Plugin-MathJax
 
 ```sh
 npm install eleventy-plugin-mathjax
 ```
 
-#### Use
+#### Use Eleventy-Plugin-MathJax
 
 ```js
 // ./.eleventy.js
@@ -572,7 +595,10 @@ module.exports = function(eleventyConfig) {
 };
 ```
 
-https://github.com/tsung-ju/eleventy-plugin-mathjax
+#### More Info on Eleventy-Plugin-MathJax
+
+* [Eleventy-Plugin-MathJax on Github][plug-mathjax-11ty]
+
 
 ## References
 
@@ -594,6 +620,7 @@ https://github.com/tsung-ju/eleventy-plugin-mathjax
 * [Markdown-It Plugins: @mdit/plugin-mathjax][mdit-plug-mathjax]
 * [Markdown-It Plugins: @mdit/plugin-tex][mdit-plug-tex]
 * [Markdown It Plugin: MathJax3 (from npmjs.com by nzt)][mdit-mathjax3]
+* [Eleventy-Plugin-MathJax on Github][plug-mathjax-11ty]
 
 <!-- Hidden Reference Links Below Here -->
 [11ty]: 11ty.dev "Eleventy (11ty) Homepage"
@@ -612,6 +639,7 @@ https://github.com/tsung-ju/eleventy-plugin-mathjax
 [mdit-plug-mathjax]: https://mdit-plugins.github.io/mathjax.html "Markdown-It Plugins: @mdit/plugin mathjax"
 [mdit-plug-tex]: https://mdit-plugins.github.io/tex.html "Markdown-It Plugins: @mdit/plugin-tex"
 [mdit-mathjax3]: https://www.npmjs.com/package/markdown-it-mathjax3 "Markdown It Plugin: MathJax3 (from npmjs.com by nzt)"
+[plug-mathjax-11ty]: https://github.com/tsung-ju/eleventy-plugin-mathjax "Eleventy-Plugin-MathJax on Github"
 
 ### Note Links
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@11ty/eleventy": "^1.0.2",
+        "@11ty/eleventy-plugin-syntaxhighlight": "^4.2.0",
         "eleventy-plugin-mathjax": "^2.0.4"
       }
     },
@@ -71,6 +72,20 @@
       },
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/11ty"
+      }
+    },
+    "node_modules/@11ty/eleventy-plugin-syntaxhighlight": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-syntaxhighlight/-/eleventy-plugin-syntaxhighlight-4.2.0.tgz",
+      "integrity": "sha512-Hf/26vyLvkAM1RCCoSNRHhWWhTOiBxJj4RMaerPXgWEGN9NEio2Xo7lCV527A/dCJN96gIWzjfHqTIk396zf6g==",
+      "dev": true,
+      "dependencies": {
+        "linkedom": "^0.14.19",
+        "prismjs": "^1.29.0"
       },
       "funding": {
         "type": "opencollective",
@@ -493,6 +508,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -843,6 +864,40 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dev": true,
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -912,7 +967,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
       "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
@@ -926,7 +981,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
       "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
-      "optional": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -938,19 +993,19 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/fb55"
         }
-      ],
-      "optional": true
+      ]
     },
     "node_modules/domhandler": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
       "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "domelementtype": "^2.3.0"
       },
@@ -965,7 +1020,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
       "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -1571,10 +1626,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "dev": true
+    },
     "node_modules/htmlparser2": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
       "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+      "devOptional": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -1582,7 +1644,6 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ],
-      "optional": true,
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
@@ -1594,7 +1655,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
       "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
-      "optional": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -1932,6 +1993,19 @@
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
       "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==",
       "dev": true
+    },
+    "node_modules/linkedom": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.14.23.tgz",
+      "integrity": "sha512-odoeP5slQkVTXPybnQku9AJUc8EOw5sqrNXi/q3pW6YaqIwURdA5A+JFzI6lN5b0Z+UrwTg475Qd+4JtfW034A==",
+      "dev": true,
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "cssom": "^0.5.0",
+        "html-escaper": "^3.0.3",
+        "htmlparser2": "^8.0.1",
+        "uhyphen": "^0.1.0"
+      }
     },
     "node_modules/linkify-it": {
       "version": "4.0.1",
@@ -2372,10 +2446,22 @@
     },
     "node_modules/notes": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/marcus-grant/notes.git#73e4f7aa8b79e6027c460d45207de652149ce032",
+      "resolved": "git+ssh://git@github.com/marcus-grant/notes.git#2fb6b8abc5e92b90d009216d3be7d7a3b462db52",
       "license": "ISC",
       "dependencies": {
         "mdman": "github:marcus-grant/mdman"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/nunjucks": {
@@ -2564,6 +2650,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
+      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/promise": {
@@ -3601,6 +3696,12 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/uhyphen": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.1.0.tgz",
+      "integrity": "sha512-o0QVGuFg24FK765Qdd5kk0zU/U4dEsCtN/GSiwNI9i8xsSVtjIAOdTaVhLwZ1nrbWxFVMxNDDl+9fednsOMsBw==",
+      "dev": true
     },
     "node_modules/universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@11ty/eleventy": "^1.0.2",
+    "@11ty/eleventy-plugin-syntaxhighlight": "^4.2.0",
     "eleventy-plugin-mathjax": "^2.0.4"
   }
 }


### PR DESCRIPTION
This only adds basic functionality of prismjs on the page. The markup is properly rendered but much more configuration including CSS sheets for the highlighting style is needed. Probably better to get started on enclosing notes markdown templates within standard layouts and basic Tailwind CSS workflows before finishing this task