### PR TITLE
Fix external links becoming undefined #23

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -17,10 +17,11 @@ const transformImageLink = function(link, url) {
 
 const replaceLink = function(link, env, token) {
   const { url } = env.meta;
-  let result;
-  if (token.type === 'link_open') {
-    result = link.endsWith('.md') ? transformMarkdownLink(link, url) : undefined;
-  } else if (token.type === 'image') {
+  let result = link;
+  if (token.type === 'link_open' && link.includes('.md')) {
+      result = transformMarkdownLink(link, url);
+  } 
+  else if (token.type === 'image') {
     result = transformImageLink(link, url);
   }
   return result;


### PR DESCRIPTION
* In #9 the fix was wrongfully making links undefined
* This was because the conditional else assumes wrongfully... * ... that all incoming links are markdown links, theyre note
* To fix this simply use `replaceLink` where the default case... * ... is to reuse the passed link